### PR TITLE
 Add namespace to provider authority to prevent crashes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ---------
 
+#### Version 0.9.3 (09.05.2019)
+- Add namespace to provider authority to prevent crashes on Android.
+
 #### Version 0.9.2 (20.12.2018)
 - Prevent progressbar timer from being reset when updating the progress value.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-local-notification",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Schedules and queries for local notifications",
   "cordova": {
     "id": "cordova-plugin-local-notification",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="0.9.2">
+        version="0.9.3">
 
     <name>LocalNotification</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,7 +103,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <provider
                 android:name="de.appplant.cordova.plugin.notification.util.AssetProvider"
-                android:authorities="${applicationId}.provider"
+                android:authorities="${applicationId}.localnotifications.provider"
                 android:exported="false"
                 android:grantUriPermissions="true" >
                 <meta-data

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -357,7 +357,7 @@ public final class AssetUtil {
      */
     private Uri getUriFromFile(File file) {
         try {
-            String authority = context.getPackageName() + ".provider";
+            String authority = context.getPackageName() + ".localnotifications.provider";
             return AssetProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();


### PR DESCRIPTION
Fix issue #17 where app crashes due to `NullPointerException on android.support.v4.content.FileProvider.parsePathStrategy`, noticed in the Google Play console vitals for a live Android application running this plugin. 

Caused by a collision of provider authority names with other plugins - `cordova-plugin-camera`, `cordova-plugin-email-composer`, tested on physical Android device 8.0.